### PR TITLE
Add obsolescence notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # ConstraintsFromTemplates [![Build Status](https://travis-ci.org/WikidataQuality/ConstraintsFromTemplates.svg?branch=master)](https://travis-ci.org/WikidataQuality/ConstraintsFromTemplates) [![Coverage Status](https://coveralls.io/repos/WikidataQuality/ConstraintsFromTemplates/badge.svg)](https://coveralls.io/r/WikidataQuality/ConstraintsFromTemplates) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/WikidataQuality/ConstraintsFromTemplates/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/WikidataQuality/ConstraintsFromTemplates/?branch=master)
-Parses the property talk pages of Wikidata to extract the constraints and initially fill the constraints table for the WikidataQualityConstraints extension.
+Parses the property talk pages of Wikidata to extract the constraints and initially fill the constraints table for the WikibaseQualityConstraints extension.
+
+## Obsolescence Notice
+
+**This repository is obsolete.**
+Since July 2017, constraints are defined in statements on properties,
+not in templates on property talk pages
+(see [T169647]),
+and since August of the same year,
+the WikibaseQualityConstraints extension no longer supports constraint definitions
+that were formerly imported from templates
+(see [T171291]).
+The repository is kept for historic interest only.
+
+[T169647]: https://phabricator.wikimedia.org/T169647
+[T171291]: https://phabricator.wikimedia.org/T171291
 
 ## Installation
 ```


### PR DESCRIPTION
Also corrects the name of the WikibaseQualityConstraints extension.

---

~~**DO NOT MERGE** until T171291 is actually done. (It might even slip to September, in which case the commit needs to be adjusted.)~~ T171291 is done, and didn’t slip to September :)